### PR TITLE
Fix reconcile existing service

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -875,7 +875,7 @@ func (c *Client) CreateOrUpdateService(svc *v1.Service) error {
 	}
 
 	svc.ResourceVersion = s.ResourceVersion
-	if svc.Spec.Type == v1.ServiceTypeClusterIP {
+	if svc.Spec.Type == "" || svc.Spec.Type == v1.ServiceTypeClusterIP {
 		svc.Spec.ClusterIP = s.Spec.ClusterIP
 	}
 


### PR DESCRIPTION
The default Service Type is ClusterIP, so in case it is not define we want to behave as if it was of that type when reconciling a Service.

Fixes issue #15 